### PR TITLE
Add Google Ads expanded staging models and pipeline resources

### DIFF
--- a/dbt_project/models/compat/google_ads_shopping_performance.sql
+++ b/dbt_project/models/compat/google_ads_shopping_performance.sql
@@ -1,0 +1,2 @@
+-- Product-level shopping performance for AI recommendation system
+select * from {{ ref('stg_google_ads__shopping_performance') }}

--- a/dbt_project/models/sources/src_google_ads.yml
+++ b/dbt_project/models/sources/src_google_ads.yml
@@ -43,3 +43,57 @@ sources:
             tests: [not_null]
           - name: search_term
             tests: [not_null]
+
+      - name: bidding_strategy
+        description: "Google Ads bidding strategies with tCPA and tROAS targets"
+        columns:
+          - name: bidding_strategy_id
+            tests: [not_null]
+
+      - name: conversion_action
+        description: "Google Ads conversion actions and tracking configuration"
+        columns:
+          - name: conversion_action_id
+            tests: [not_null]
+
+      - name: shopping_performance
+        description: "Google Ads shopping performance by product (last 90 days, daily)"
+        columns:
+          - name: date_start
+            tests: [not_null]
+          - name: campaign_id
+            tests: [not_null]
+          - name: product_item_id
+            tests: [not_null]
+
+      - name: asset_group
+        description: "Google Ads PMAX asset groups"
+        columns:
+          - name: asset_group_id
+            tests: [not_null]
+
+      - name: asset_group_asset
+        description: "Google Ads PMAX asset group assets (headlines, descriptions, images, shopping feed)"
+        columns:
+          - name: asset_resource_name
+            tests: [not_null]
+
+      - name: campaign_asset_set
+        description: "Google Ads campaign asset set linkages — confirms shopping feed attached to PMAX"
+        columns:
+          - name: campaign_id
+            tests: [not_null]
+
+      - name: geographic_view
+        description: "Google Ads geographic performance by country (last 90 days, daily)"
+        columns:
+          - name: date_start
+            tests: [not_null]
+          - name: campaign_id
+            tests: [not_null]
+
+      - name: campaign_audience_view
+        description: "Google Ads campaign audience performance for observational audiences"
+        columns:
+          - name: resource_name
+            tests: [not_null]

--- a/dbt_project/models/staging/google_ads/_google_ads__models.yml
+++ b/dbt_project/models/staging/google_ads/_google_ads__models.yml
@@ -42,3 +42,67 @@ models:
         tests: [not_null]
       - name: search_term
         tests: [not_null]
+
+  - name: stg_google_ads__bidding_strategy
+    description: "Staged Google Ads bidding strategies with tCPA/tROAS targets in dollars"
+    columns:
+      - name: bidding_strategy_id
+        tests: [not_null]
+
+  - name: stg_google_ads__conversion_action
+    description: "Staged Google Ads conversion actions with tracking configuration"
+    columns:
+      - name: conversion_action_id
+        tests: [not_null]
+
+  - name: stg_google_ads__shopping_performance
+    description: "Staged Google Ads shopping performance — product-level metrics (last 90 days, daily)"
+    columns:
+      - name: date_start
+        tests: [not_null]
+      - name: campaign_id
+        tests: [not_null]
+      - name: product_item_id
+        tests: [not_null]
+
+  - name: stg_google_ads__asset_group
+    description: "Staged Google Ads PMAX asset groups"
+    columns:
+      - name: asset_group_id
+        tests: [not_null]
+      - name: campaign_id
+        tests: [not_null]
+
+  - name: stg_google_ads__asset_group_asset
+    description: "Staged Google Ads PMAX asset group assets (headlines, descriptions, images)"
+    columns:
+      - name: asset_resource_name
+        tests: [not_null]
+      - name: asset_group_id
+        tests: [not_null]
+
+  - name: stg_google_ads__campaign_asset_set
+    description: "Staged Google Ads campaign asset sets — confirms shopping feed linkage to PMAX"
+    columns:
+      - name: campaign_id
+        tests: [not_null]
+      - name: asset_set_id
+        tests: [not_null]
+
+  - name: stg_google_ads__geographic_view
+    description: "Staged Google Ads geographic performance (last 90 days, daily)"
+    columns:
+      - name: date_start
+        tests: [not_null]
+      - name: campaign_id
+        tests: [not_null]
+      - name: country_criterion_id
+        tests: [not_null]
+
+  - name: stg_google_ads__campaign_audience_view
+    description: "Staged Google Ads campaign audience performance (observational audiences)"
+    columns:
+      - name: resource_name
+        tests: [not_null]
+      - name: campaign_id
+        tests: [not_null]

--- a/dbt_project/models/staging/google_ads/stg_google_ads__asset_group.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__asset_group.sql
@@ -1,0 +1,17 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'asset_group') }}
+),
+
+renamed as (
+    select
+        cast(asset_group_id as int64) as asset_group_id,
+        asset_group_name,
+        status,
+        final_urls,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__asset_group_asset.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__asset_group_asset.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'asset_group_asset') }}
+),
+
+renamed as (
+    select
+        asset_resource_name,
+        field_type,
+        status,
+        cast(asset_group_id as int64) as asset_group_id,
+        asset_group_name,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__bidding_strategy.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__bidding_strategy.sql
@@ -1,0 +1,17 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'bidding_strategy') }}
+),
+
+renamed as (
+    select
+        cast(bidding_strategy_id as int64) as bidding_strategy_id,
+        bidding_strategy_name,
+        bidding_strategy_type,
+        safe_divide(cast(target_cpa_micros as float64), 1000000) as target_cpa,
+        cast(target_roas as float64) as target_roas,
+        safe_divide(cast(maximize_conversions_target_cpa_micros as float64), 1000000) as maximize_conversions_target_cpa
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__campaign_asset_set.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__campaign_asset_set.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'campaign_asset_set') }}
+),
+
+renamed as (
+    select
+        campaign_resource_name,
+        asset_set_resource_name,
+        status,
+        cast(asset_set_id as int64) as asset_set_id,
+        asset_set_name,
+        asset_set_type,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__campaign_audience_view.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__campaign_audience_view.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'campaign_audience_view') }}
+),
+
+renamed as (
+    select
+        resource_name,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name,
+        cast(impressions as int64) as impressions,
+        cast(clicks as int64) as clicks,
+        cast(spend as float64) as spend,
+        cast(conversions as float64) as conversions,
+        cast(conversion_value as float64) as conversion_value
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__conversion_action.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__conversion_action.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'conversion_action') }}
+),
+
+renamed as (
+    select
+        cast(conversion_action_id as int64) as conversion_action_id,
+        conversion_action_name,
+        status,
+        conversion_type,
+        cast(default_value as float64) as default_value,
+        cast(always_use_default_value as bool) as always_use_default_value,
+        counting_type,
+        cast(include_in_conversions_metric as bool) as include_in_conversions_metric
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__geographic_view.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__geographic_view.sql
@@ -1,0 +1,21 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'geographic_view') }}
+),
+
+renamed as (
+    select
+        cast(date_start as date) as date_start,
+        location_type,
+        cast(country_criterion_id as int64) as country_criterion_id,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name,
+        cast(impressions as int64) as impressions,
+        cast(clicks as int64) as clicks,
+        cast(spend as float64) as spend,
+        cast(conversions as float64) as conversions,
+        cast(conversion_value as float64) as conversion_value
+
+    from source
+)
+
+select * from renamed

--- a/dbt_project/models/staging/google_ads/stg_google_ads__shopping_performance.sql
+++ b/dbt_project/models/staging/google_ads/stg_google_ads__shopping_performance.sql
@@ -1,0 +1,23 @@
+with source as (
+    select * from {{ source('raw_google_ads', 'shopping_performance') }}
+),
+
+renamed as (
+    select
+        cast(date_start as date) as date_start,
+        product_title,
+        product_item_id,
+        product_type_l1,
+        product_brand,
+        cast(campaign_id as int64) as campaign_id,
+        campaign_name,
+        cast(impressions as int64) as impressions,
+        cast(clicks as int64) as clicks,
+        cast(spend as float64) as spend,
+        cast(conversions as float64) as conversions,
+        cast(conversion_value as float64) as conversion_value
+
+    from source
+)
+
+select * from renamed

--- a/pipelines/google_ads/source.py
+++ b/pipelines/google_ads/source.py
@@ -1,4 +1,4 @@
-"""dlt source for Google Ads — 5 resources: campaigns, ad_groups, keywords, daily_insights, search_terms."""
+"""dlt source for Google Ads — 13 resources: campaigns, ad_groups, keywords, daily_insights, search_terms, bidding_strategy, conversion_action, shopping_performance, asset_group, asset_group_asset, campaign_asset_set, geographic_view, campaign_audience_view."""
 
 import logging
 from datetime import date, timedelta
@@ -21,7 +21,7 @@ def google_ads_source(
     login_customer_id: str = "",
     days_back: int = 3,
 ):
-    """dlt source yielding 5 Google Ads resources."""
+    """dlt source yielding 13 Google Ads resources."""
     client = GoogleAdsApiClient(
         customer_id=customer_id,
         developer_token=developer_token,
@@ -34,12 +34,21 @@ def google_ads_source(
 
     end_date = date.today() - timedelta(days=1)
     start_date = end_date - timedelta(days=days_back - 1)
+    start_date_90d = date.today() - timedelta(days=91)
 
     yield _campaigns_resource(client)
     yield _ad_groups_resource(client)
     yield _keywords_resource(client)
     yield _daily_insights_resource(client, start_date, end_date)
     yield _search_terms_resource(client, start_date, end_date)
+    yield _bidding_strategy_resource(client)
+    yield _conversion_action_resource(client)
+    yield _shopping_performance_resource(client, start_date_90d, end_date)
+    yield _asset_group_resource(client)
+    yield _asset_group_asset_resource(client)
+    yield _campaign_asset_set_resource(client)
+    yield _geographic_view_resource(client, start_date_90d, end_date)
+    yield _campaign_audience_view_resource(client)
 
 
 def _campaigns_resource(client: GoogleAdsApiClient):
@@ -272,3 +281,280 @@ def _search_terms_resource(client: GoogleAdsApiClient, start_date: date, end_dat
             }
 
     return search_terms
+
+
+def _bidding_strategy_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="bidding_strategy", write_disposition="replace")
+    def bidding_strategy():
+        ingested = now_utc_str()
+        # campaign fields are not selectable from the bidding_strategy resource
+        query = """
+            SELECT
+                bidding_strategy.id,
+                bidding_strategy.name,
+                bidding_strategy.type,
+                bidding_strategy.target_cpa.target_cpa_micros,
+                bidding_strategy.target_roas.target_roas,
+                bidding_strategy.maximize_conversions.target_cpa_micros
+            FROM bidding_strategy
+        """
+        for row in client.query(query):
+            yield {
+                "bidding_strategy_id": row.bidding_strategy.id,
+                "bidding_strategy_name": row.bidding_strategy.name,
+                "bidding_strategy_type": row.bidding_strategy.type_.name,
+                "target_cpa_micros": row.bidding_strategy.target_cpa.target_cpa_micros or None,
+                "target_roas": row.bidding_strategy.target_roas.target_roas or None,
+                "maximize_conversions_target_cpa_micros": row.bidding_strategy.maximize_conversions.target_cpa_micros or None,
+                "ingested_at": ingested,
+            }
+
+    return bidding_strategy
+
+
+def _conversion_action_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="conversion_action", write_disposition="replace")
+    def conversion_action():
+        ingested = now_utc_str()
+        query = """
+            SELECT
+                conversion_action.id,
+                conversion_action.name,
+                conversion_action.status,
+                conversion_action.type,
+                conversion_action.value_settings.default_value,
+                conversion_action.value_settings.always_use_default_value,
+                conversion_action.counting_type,
+                conversion_action.include_in_conversions_metric
+            FROM conversion_action
+        """
+        for row in client.query(query):
+            yield {
+                "conversion_action_id": row.conversion_action.id,
+                "conversion_action_name": row.conversion_action.name,
+                "status": row.conversion_action.status.name,
+                "conversion_type": row.conversion_action.type_.name,
+                "default_value": row.conversion_action.value_settings.default_value or None,
+                "always_use_default_value": row.conversion_action.value_settings.always_use_default_value,
+                "counting_type": row.conversion_action.counting_type.name,
+                "include_in_conversions_metric": row.conversion_action.include_in_conversions_metric,
+                "ingested_at": ingested,
+            }
+
+    return conversion_action
+
+
+def _shopping_performance_resource(client: GoogleAdsApiClient, start_date: date, end_date: date):
+    @dlt.resource(
+        name="shopping_performance",
+        write_disposition="merge",
+        merge_key=["date_start", "product_item_id", "campaign_id"],
+        primary_key=["date_start", "product_item_id", "campaign_id"],
+    )
+    def shopping_performance():
+        ingested = now_utc_str()
+        query = f"""
+            SELECT
+                segments.date,
+                segments.product_title,
+                segments.product_item_id,
+                segments.product_type_l1,
+                segments.product_brand,
+                campaign.id,
+                campaign.name,
+                metrics.impressions,
+                metrics.clicks,
+                metrics.cost_micros,
+                metrics.conversions,
+                metrics.conversions_value
+            FROM shopping_performance_view
+            WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'
+                AND metrics.impressions > 0
+        """
+        for row in client.query(query):
+            yield {
+                "date_start": row.segments.date,
+                "product_title": row.segments.product_title,
+                "product_item_id": row.segments.product_item_id,
+                "product_type_l1": row.segments.product_type_l1,
+                "product_brand": row.segments.product_brand,
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "impressions": row.metrics.impressions,
+                "clicks": row.metrics.clicks,
+                "spend": row.metrics.cost_micros / 1_000_000,
+                "conversions": row.metrics.conversions,
+                "conversion_value": row.metrics.conversions_value,
+                "ingested_at": ingested,
+            }
+
+    return shopping_performance
+
+
+def _asset_group_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="asset_group", write_disposition="replace")
+    def asset_group():
+        ingested = now_utc_str()
+        query = """
+            SELECT
+                asset_group.id,
+                asset_group.name,
+                asset_group.status,
+                asset_group.final_urls,
+                campaign.id,
+                campaign.name
+            FROM asset_group
+            WHERE asset_group.status != 'REMOVED'
+        """
+        for row in client.query(query):
+            yield {
+                "asset_group_id": row.asset_group.id,
+                "asset_group_name": row.asset_group.name,
+                "status": row.asset_group.status.name,
+                "final_urls": list(row.asset_group.final_urls),
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "ingested_at": ingested,
+            }
+
+    return asset_group
+
+
+def _asset_group_asset_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="asset_group_asset", write_disposition="replace")
+    def asset_group_asset():
+        ingested = now_utc_str()
+        query = """
+            SELECT
+                asset_group_asset.asset,
+                asset_group_asset.field_type,
+                asset_group_asset.status,
+                asset_group.id,
+                asset_group.name,
+                campaign.id,
+                campaign.name
+            FROM asset_group_asset
+            WHERE asset_group_asset.status != 'REMOVED'
+        """
+        for row in client.query(query):
+            yield {
+                "asset_resource_name": row.asset_group_asset.asset,
+                "field_type": row.asset_group_asset.field_type.name,
+                "status": row.asset_group_asset.status.name,
+                "asset_group_id": row.asset_group.id,
+                "asset_group_name": row.asset_group.name,
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "ingested_at": ingested,
+            }
+
+    return asset_group_asset
+
+
+def _campaign_asset_set_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="campaign_asset_set", write_disposition="replace")
+    def campaign_asset_set():
+        ingested = now_utc_str()
+        query = """
+            SELECT
+                campaign_asset_set.campaign,
+                campaign_asset_set.asset_set,
+                campaign_asset_set.status,
+                asset_set.id,
+                asset_set.name,
+                asset_set.type,
+                campaign.id,
+                campaign.name
+            FROM campaign_asset_set
+            WHERE campaign_asset_set.status != 'REMOVED'
+        """
+        for row in client.query(query):
+            yield {
+                "campaign_resource_name": row.campaign_asset_set.campaign,
+                "asset_set_resource_name": row.campaign_asset_set.asset_set,
+                "status": row.campaign_asset_set.status.name,
+                "asset_set_id": row.asset_set.id,
+                "asset_set_name": row.asset_set.name,
+                "asset_set_type": row.asset_set.type_.name,
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "ingested_at": ingested,
+            }
+
+    return campaign_asset_set
+
+
+def _geographic_view_resource(client: GoogleAdsApiClient, start_date: date, end_date: date):
+    @dlt.resource(
+        name="geographic_view",
+        write_disposition="merge",
+        merge_key=["date_start", "campaign_id", "country_criterion_id"],
+        primary_key=["date_start", "campaign_id", "country_criterion_id"],
+    )
+    def geographic_view():
+        ingested = now_utc_str()
+        query = f"""
+            SELECT
+                geographic_view.location_type,
+                geographic_view.country_criterion_id,
+                campaign.id,
+                campaign.name,
+                segments.date,
+                metrics.impressions,
+                metrics.clicks,
+                metrics.cost_micros,
+                metrics.conversions,
+                metrics.conversions_value
+            FROM geographic_view
+            WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'
+                AND metrics.impressions > 0
+        """
+        for row in client.query(query):
+            yield {
+                "date_start": row.segments.date,
+                "location_type": row.geographic_view.location_type.name,
+                "country_criterion_id": row.geographic_view.country_criterion_id,
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "impressions": row.metrics.impressions,
+                "clicks": row.metrics.clicks,
+                "spend": row.metrics.cost_micros / 1_000_000,
+                "conversions": row.metrics.conversions,
+                "conversion_value": row.metrics.conversions_value,
+                "ingested_at": ingested,
+            }
+
+    return geographic_view
+
+
+def _campaign_audience_view_resource(client: GoogleAdsApiClient):
+    @dlt.resource(name="campaign_audience_view", write_disposition="replace")
+    def campaign_audience_view():
+        ingested = now_utc_str()
+        # ad_group_criterion fields are not selectable from campaign_audience_view
+        query = """
+            SELECT
+                campaign_audience_view.resource_name,
+                campaign.id,
+                campaign.name,
+                metrics.impressions,
+                metrics.clicks,
+                metrics.cost_micros,
+                metrics.conversions,
+                metrics.conversions_value
+            FROM campaign_audience_view
+        """
+        for row in client.query(query):
+            yield {
+                "resource_name": row.campaign_audience_view.resource_name,
+                "campaign_id": row.campaign.id,
+                "campaign_name": row.campaign.name,
+                "impressions": row.metrics.impressions,
+                "clicks": row.metrics.clicks,
+                "spend": row.metrics.cost_micros / 1_000_000,
+                "conversions": row.metrics.conversions,
+                "conversion_value": row.metrics.conversions_value,
+                "ingested_at": ingested,
+            }
+
+    return campaign_audience_view


### PR DESCRIPTION
## Summary
- Extended `pipelines/google_ads/source.py` with 8 new dlt resources: `asset_group`, `asset_group_asset`, `bidding_strategy`, `campaign_asset_set`, `campaign_audience_view`, `conversion_action`, `geographic_view`, `shopping_performance`
- Added corresponding dbt staging models for each new resource
- Updated `src_google_ads.yml` source definitions and `_google_ads__models.yml` column docs
- Added `compat/google_ads_shopping_performance.sql` view for backwards compatibility

## Test plan
- [ ] Run `python -m pipelines.run google-ads --days 7 --destination duckdb` to verify new resources extract without errors
- [ ] Run `cd dbt_project && dbt run --select staging.google_ads` to verify staging models compile and run
- [ ] Run `dbt test --select staging.google_ads` to check tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)